### PR TITLE
Added trim and null possibility in the service layer for getUserByNam…

### DIFF
--- a/src/main/java/org/basr/pinpoint/service/UserService.java
+++ b/src/main/java/org/basr/pinpoint/service/UserService.java
@@ -60,12 +60,14 @@ public class UserService {
 
     public List<User> getUserByName(String firstName, String lastName) {
         List<User> users;
+        firstName = StringUtils.hasText(firstName) ? firstName.trim() : null;
+        lastName = StringUtils.hasText(lastName) ? lastName.trim() : null;
 
-        if (StringUtils.hasText(firstName) && StringUtils.hasText(lastName)) {
+        if (firstName != null && lastName != null) {
             users = repos.findByFirstNameAndLastName(firstName, lastName);
-        } else if (StringUtils.hasText(firstName)) {
+        } else if (firstName != null) {
             users = repos.findByFirstName(firstName);
-        } else if (StringUtils.hasText(lastName)) {
+        } else if (lastName != null) {
             users = repos.findByLastName(lastName);
         } else {
             return List.of();


### PR DESCRIPTION
…e so false positives from empty frontend requests cant give all users as result. This should fix the full user DB being sent on searching on firstname only